### PR TITLE
Software-Mangaed TLB Lab

### DIFF
--- a/labs/x-sw-tlb/README.md
+++ b/labs/x-sw-tlb/README.md
@@ -1,3 +1,96 @@
-# Software TLB
+# Software-Managed TLB
 
-TODO
+It seems that some processors forego having a hardware page-table walker.
+Instead, a TLB miss causes an exception, and it's the operating system's
+responsibility to populate the relevant TLB entries so that hardware can use it.
+This is termed a "[Software-Managed TLB][1]".
+
+While our processor has a hardware page-table walker, there's an option to
+disable it in the Translation Table Base Control Register (DDI 0301H § 3.2.15).
+As a result, we can create a software-managed TLB using the lockdown region,
+just as we did in CS 140E [Lab 15][2].
+
+## Task Description
+
+Your task is to provide the illusion that memory exists in the upper half of the
+address space - from `0x80000000` up to `0xffffffff` (inclusive). You can do
+this by assuming that programs will never try to use all of that address space
+at once, so you can dynamically allocate pages "on the fly" as software reads
+and writes them.
+
+To do this, you must write the `sw_tlb_handler_initialize` method in
+`sw-tlb-handler.c`. That function should install exception handlers for data and
+prefetch aborts. It can also allocate any necessary metadata for the exception
+handlers.
+
+The handlers themselves should find what virtual address faulted, figure out how
+to map it into physical memory, then install the mapping in the TLB. You can do
+this however you want, subject to the following constraints:
+  * You must preserve true memory dependencies. If I write data to an address,
+    then read it back, I should read what I wrote.
+  * All pages must be zero-initialized. Reading from this "fake" memory without
+    having written to it previously should return zero.
+  * You must be able to have at least two mappings in the software-managed TLB
+    at one time - one for instructions and one for data.
+  * All large structures must be allocated on the heap with `kmalloc` or its
+    variants. You have 15MiB to work with.
+
+Consider the runtime of your exception handlers. They should be short, and
+ideally operate in constant time. They must be sub-linear - their runtime cannot
+scale as `O(m)` where `m` is the memory usage of the application. Also consider
+the page size to use. The tests for this lab access data in 4KiB chunks, so a
+1MiB page size might cause too much internal fragmentation, especially since you
+only have 15MiB of physical memory to work with. Finally consider how many times
+your exception handlers need to be called. Try to keep entries in the TLB so you
+don't have to repopulate them as often.
+
+## Approaches
+
+You can emulate the radix-tree structure used by hardware. But, I initially
+designed this lab to teach [Inverted Page Tables][3]. The key idea is that, if
+we don't care where exactly a virtual page gets placed in physical memory, we
+can have the mapping defined by a hash function on the virtual page number. This
+skips having to store the mapping explicitly, which either requires a lot of
+memory or a lot of levels, especially with 64-bit address spaces. To deal with
+collisions, you just store the reverse mapping in a frame table, and check
+whether the virtual page number currently occupying the physical frame is the
+one you're trying to use. If there's a mismatch, you can use some probing
+technique, like linear probing or cuckoo hashing, to find the correct slot.
+
+This is actually *not* what I implemented in my solution. I didn't like the
+memory use for applications that don't use the whole physical address space, and
+I didn't like that the frame table can't easily be resized to accomodate
+different loads. Instead, I use use a [hashmap][4] to store the existing
+mappings from virtual page numbers to physical frame numbers, and I allocate
+physical frames as they're needed.
+
+But anything goes as long as it fits the requirements.
+
+## Possible Extensions
+* Experiment with different eviction policies. I used round-robin, but check to
+  see if random eviction works better. Also try to get LRU working.
+* Experiment with different load factors if you used an inverted page table or a
+  hash map. See which one results in the fewest probes.
+* Experiment with different page sizes if you used a radix tree. Measure the
+  fragmentation for each of them.
+* Implement a [zero page][5]. Initially, redirect all reads to a single physical
+  frame populated entirely with zeros. Only allocate a separate frame when the
+  application actually writes to it.
+* Port your allocation code to use the hardware page-table walker. With that,
+  the point of the lab would more so shift to frame allocation.
+
+[1]:
+    https://en.wikipedia.org/wiki/Translation_lookaside_buffer#TLB-miss_handling
+    "Translation Lookaside Buffer - TLB-Miss Handling"
+[2]:
+    https://github.com/dddrrreee/cs140e-24win/tree/main/labs/15-pinned-vm
+    "15: Pinned VM"
+[3]:
+    https://cs.stackexchange.com/questions/84764/difference-between-inverted-page-table-and-a-standard-one
+    "Difference between inverted page table and a standard one?"
+[4]:
+    https://www.youtube.com/watch?v=kVgy1GSDHG8
+    "Coding Interviews Be Like"
+[5]:
+    https://stackoverflow.com/a/35550384
+    "Linux kernel: Role of zero page allocation at paging_init time"

--- a/labs/x-sw-tlb/README.md
+++ b/labs/x-sw-tlb/README.md
@@ -1,0 +1,3 @@
+# Software TLB
+
+TODO

--- a/labs/x-sw-tlb/code/Makefile
+++ b/labs/x-sw-tlb/code/Makefile
@@ -8,5 +8,6 @@ COMMON_SRC += sw-tlb-map.c
 
 BOOTLOADER=my-install
 RUN = 1
+CAN_EMIT=1
 
 include $(CS240LX_2024_PATH)/libpi/mk/Makefile.robust

--- a/labs/x-sw-tlb/code/Makefile
+++ b/labs/x-sw-tlb/code/Makefile
@@ -1,0 +1,11 @@
+PROGS := $(wildcard tests/*-test.c)
+
+COMMON_SRC += tests/common.c
+COMMON_SRC += sw-tlb-mmu-init.S
+COMMON_SRC += sw-tlb-mmu-write.c
+COMMON_SRC += sw-tlb-handler.c
+
+BOOTLOADER=my-install
+RUN = 1
+
+include $(CS240LX_2024_PATH)/libpi/mk/Makefile.robust

--- a/labs/x-sw-tlb/code/Makefile
+++ b/labs/x-sw-tlb/code/Makefile
@@ -4,6 +4,7 @@ COMMON_SRC += tests/common.c
 COMMON_SRC += sw-tlb-mmu-init.S
 COMMON_SRC += sw-tlb-mmu-write.c
 COMMON_SRC += sw-tlb-handler.c
+COMMON_SRC += sw-tlb-map.c
 
 BOOTLOADER=my-install
 RUN = 1

--- a/labs/x-sw-tlb/code/pinned-vm.h
+++ b/labs/x-sw-tlb/code/pinned-vm.h
@@ -1,0 +1,222 @@
+//! \file pinned-vm.h
+//! \brief An excerpt of the true `pinned-vm.h` file
+//!
+//! This file just contains the data structures needed to express the properties
+//! of TLB entries. All the functionality has been gutted.
+#pragma once
+
+enum { dom_kern = 1 };
+
+// this enum flag is a three bit value
+//      AXP:1 << 2 | AP:2
+// so that you can just bitwise or it into the
+// position for AP (which is adjacent to AXP).
+//
+// if _priv access = kernel only.
+// if _user access, implies kernel access (but
+// not sure if this should be default).
+//
+// see: 3-151 for table or B4-9 for more
+// discussion.
+typedef enum {
+    perm_rw_user = 0b011, // read-write user
+    perm_ro_user = 0b010, // read-only user
+    perm_na_user = 0b001, // no access user
+
+    // kernel only, user no access
+    perm_ro_priv = 0b101,
+    // perm_rw_priv = perm_na_user,
+    perm_rw_priv = perm_na_user,
+    perm_na_priv = 0b000,
+} mem_perm_t;
+
+static inline int mem_perm_islegal(mem_perm_t p) {
+    switch(p) {
+    case perm_rw_user:
+    case perm_ro_user:
+    // case perm_na_user:
+    case perm_ro_priv:
+    case perm_rw_priv:
+    case perm_na_priv:
+        return 1;
+    default:
+        // for today just die.
+        panic("illegal permission: %b\n", p);
+    }
+}
+
+// domain permisson enums: see b4-10
+enum {
+    DOM_no_access   = 0b00, // any access = fault.
+    // client accesses check against permission bits in tlb
+    DOM_client      = 0b01,
+    // don't use.
+    DOM_reserved    = 0b10,
+    // TLB access bits are ignored.
+    DOM_manager     = 0b11,
+};
+
+// caching is controlled by the TEX, C, and B bits.
+// these are laid out contiguously:
+//      TEX:3 | C:1 << 1 | B:1
+// we construct an enum with a value that maps to
+// the description so that we don't have to pass
+// a ton of parameters.
+//
+// from table 6-2 on 6-15:
+#define TEX_C_B(tex,c,b)  ((tex) << 2 | (c) << 1 | (b))
+typedef enum {
+    //                              TEX   C  B
+    // strongly ordered
+    // not shared.
+    MEM_device     =  TEX_C_B(    0b000,  0, 0),
+    // normal, non-cached
+    MEM_uncached   =  TEX_C_B(    0b001,  0, 0),
+
+    // write back no alloc
+    MEM_wb_noalloc =  TEX_C_B(    0b000,  1, 1),
+    // write through no alloc
+    MEM_wt_noalloc =  TEX_C_B(    0b000,  1, 0),
+
+    // NOTE: missing a lot!
+} mem_attr_t;
+
+// attributes: these get inserted into the TLB.
+typedef struct {
+    // for today we only handle 1MB sections.
+    uint32_t G,         // is this a global entry?
+             asid,      // don't think this should actually be in this.
+             dom,       // domain id
+             pagesize;  // can be 1MB or 16MB
+
+    // permissions for needed to access page.
+    //
+    // see mem_perm_t above: is the bit merge of
+    // APX and AP so can or into AP position.
+    mem_perm_t  AP_perm;
+
+    // caching policy for this memory.
+    //
+    // see mem_cache_t enum above.
+    // see table on 6-16 b4-8/9
+    // for today everything is uncacheable.
+    mem_attr_t mem_attr;
+} pin_t;
+
+// default:
+//  - 1mb section
+static inline pin_t
+pin_mk(uint32_t G,
+            uint32_t dom,
+            uint32_t asid,
+            mem_perm_t perm,
+            mem_attr_t mem_attr) {
+    demand(mem_perm_islegal(perm), "invalid permission: %b\n", perm);
+    demand(dom <= 16, illegal domain id);
+    if(G)
+        demand(!asid, "should not have a non-zero asid: %d", asid);
+    else {
+        demand(asid, should have non-zero asid);
+        demand(asid > 0 && asid < 64, invalid asid);
+    }
+
+
+    return (pin_t) {
+            .dom = dom,
+            .asid = asid,
+            .G = G,
+            // default: 1MB section.
+            .pagesize = 0b11,
+            // default: uncacheable
+            // .mem_attr = MEM_uncached, // mem_attr,
+            .mem_attr = mem_attr,
+            .AP_perm = perm };
+}
+
+// pattern for overriding values.
+static inline pin_t
+pin_mem_attr_set(pin_t e, mem_attr_t mem) {
+    e.mem_attr = mem;
+    return e;
+}
+
+// encoding for different page sizes.
+enum {
+    PAGE_4K     = 0b01,
+    PAGE_64K    = 0b10,
+    PAGE_1MB    = 0b11,
+    PAGE_16MB   = 0b00
+};
+
+// override default <p>
+static inline pin_t pin_16mb(pin_t p) {
+    p.pagesize = PAGE_16MB;
+    return p;
+}
+static inline pin_t pin_64k(pin_t p) {
+    p.pagesize = PAGE_64K;
+    return p;
+}
+
+// possibly we should just multiply these.
+enum {
+    _4k     = 4*1024,
+    _64k    = 64*1024,
+    _1mb    = 1024*1024,
+    _16mb   = 16*_1mb
+};
+
+// return the number of bytes for <attr>
+static inline unsigned
+pin_nbytes(pin_t attr) {
+    switch(attr.pagesize) {
+    case 0b01: return _4k;
+    case 0b10: return _64k;
+    case 0b11: return _1mb;
+    case 0b00: return _16mb;
+    default: panic("invalid pagesize\n");
+    }
+}
+
+// check page alignment. as is typical, arm1176
+// requires 1mb pages to be aligned to 1mb; 16mb
+// aligned to 16mb, etc.
+static inline unsigned
+pin_aligned(uint32_t va, pin_t attr) {
+    unsigned n = pin_nbytes(attr);
+    switch(n) {
+    case _4k:   return va % _4k == 0;
+    case _64k:  return va % _64k == 0;
+    case _1mb:  return va % _1mb == 0;
+    case _16mb: return va % _16mb == 0;
+    default: panic("invalid size=%u\n", n);
+    }
+}
+
+// make a dev entry:
+//    - global bit set.
+//    - non-cacheable
+//    - kernel R/W, user no-access
+static inline pin_t pin_mk_device(uint32_t dom) {
+    return pin_mk(1, dom, 0, perm_rw_priv, MEM_device);
+}
+
+
+// make a global entry:
+//  - global bit set
+//  - asid = 0
+//  - default: 1mb section.
+static inline pin_t
+pin_mk_global(uint32_t dom, mem_perm_t perm, mem_attr_t attr) {
+    // G=1, asid=0.
+    return pin_mk(1, dom, 0, perm, attr);
+}
+
+// must have:
+//  - global=0
+//  - asid != 0
+//  - domain should not be kernel domain (we don't check)
+static inline pin_t
+pin_mk_user(uint32_t dom, uint32_t asid, mem_perm_t perm, mem_attr_t attr) {
+    return pin_mk(0, dom, asid, perm, attr);
+}

--- a/labs/x-sw-tlb/code/pinned-vm.h
+++ b/labs/x-sw-tlb/code/pinned-vm.h
@@ -157,6 +157,10 @@ static inline pin_t pin_64k(pin_t p) {
     p.pagesize = PAGE_64K;
     return p;
 }
+static inline pin_t pin_4k(pin_t p) {
+    p.pagesize = PAGE_4K;
+    return p;
+}
 
 // possibly we should just multiply these.
 enum {

--- a/labs/x-sw-tlb/code/sw-tlb-handler.c
+++ b/labs/x-sw-tlb/code/sw-tlb-handler.c
@@ -1,22 +1,81 @@
 #include "sw-tlb-handler.h"
 
 #include "rpi.h"
+#include "asm-helpers.h"
 #include "full-except.h"
 
 #include "sw-tlb-mmu.h"
+#include "sw-tlb-map.h"
 
-volatile unsigned sw_tlb_num_exceptions = 0;
+unsigned sw_tlb_num_exceptions = 0;
+
+// Functions to determine what kind of fault was taken. We should always get
+// translation section faults.
+cp_asm_get(dfsr, p15, 0, c5, c0, 0)
+cp_asm_get(ifsr, p15, 0, c5, c0, 1)
+cp_asm_get(far, p15, 0, c6, c0, 0)
+cp_asm_get(ifar, p15, 0, c6, c0, 2)
 
 // The part of the TLB lockdown registers we're allowed to use
-static volatile unsigned lockdown_off = 8;
-static volatile unsigned lockdown_len = 0;
+static unsigned lockdown_off = 8;
+static unsigned lockdown_len = 0;
+
+// Map for storing virtual to physical mappings
+static sw_tlb_map_t map = {
+    .entries = NULL,
+    .log_capacity = 0,
+    .size = 0,
+};
+
+// Evict in a round-robin fashion. This counter holds the next index to evict.
+static unsigned round_robin_counter = 0;
+
+static void sw_tlb_handler_common(uint32_t faulting_va) {
+    assert(lockdown_len >= 2);
+    assert(map.entries != NULL);
+    assert(map.log_capacity > 0);
+    sw_tlb_num_exceptions++;
+
+    uint32_t faulting_vpn = faulting_va >> 12;
+    uint32_t faulting_pa;
+    uint32_t faulting_pfn;
+
+    int have_map = sw_tlb_map_contains(&map, faulting_vpn, &faulting_pfn);
+    if (!have_map) {
+        faulting_pa = (uint32_t)kmalloc_aligned(4096, 4096);
+        faulting_pfn = faulting_pa >> 12;
+        sw_tlb_map_add(&map, faulting_vpn, faulting_pfn);
+    } else {
+        faulting_pa = faulting_pfn << 12;
+    }
+    assert(faulting_va >> 12 == faulting_vpn);
+    assert(faulting_pa >> 12 == faulting_pfn);
+
+    assert(round_robin_counter < lockdown_len);
+    sw_tlb_set(
+        lockdown_off + round_robin_counter, faulting_va, faulting_pa,
+        pin_4k(pin_mk_global(dom_kern, perm_rw_priv, MEM_wb_noalloc)));
+    round_robin_counter++;
+    if (round_robin_counter >= lockdown_len)
+        round_robin_counter = 0;
+}
 
 static void sw_tlb_handler_i(regs_t *r) {
-    panic("Prefetch abort at %x\n", r->regs[REGS_PC]);
+    // We should only get translation section faults
+    assert((ifsr_get() & 0x40fu) == 0x005u);
+
+    uint32_t addr = ifar_get();
+    output("prefetch abort for %x\n", addr);
+    sw_tlb_handler_common(addr);
 }
 
 static void sw_tlb_handler_d(regs_t *r) {
-    panic("Data abort at %x\n", r->regs[REGS_PC]);
+    // We should only get translation section faults
+    assert((dfsr_get() & 0x40fu) == 0x005u);
+
+    uint32_t addr = far_get();
+    output("data abort for %x\n", addr);
+    sw_tlb_handler_common(addr);
 }
 
 void sw_tlb_handler_initialize(unsigned lockdown_start_idx) {
@@ -24,6 +83,8 @@ void sw_tlb_handler_initialize(unsigned lockdown_start_idx) {
     assert(lockdown_start_idx < 8);
     lockdown_off = lockdown_start_idx;
     lockdown_len = 8 - lockdown_start_idx;
+
+    map = sw_tlb_map_create();
 
     full_except_set_prefetch(sw_tlb_handler_i);
     full_except_set_data_abort(sw_tlb_handler_d);

--- a/labs/x-sw-tlb/code/sw-tlb-handler.c
+++ b/labs/x-sw-tlb/code/sw-tlb-handler.c
@@ -1,0 +1,30 @@
+#include "sw-tlb-handler.h"
+
+#include "rpi.h"
+#include "full-except.h"
+
+#include "sw-tlb-mmu.h"
+
+volatile unsigned sw_tlb_num_exceptions = 0;
+
+// The part of the TLB lockdown registers we're allowed to use
+static volatile unsigned lockdown_off = 8;
+static volatile unsigned lockdown_len = 0;
+
+static void sw_tlb_handler_i(regs_t *r) {
+    panic("Prefetch abort at %x\n", r->regs[REGS_PC]);
+}
+
+static void sw_tlb_handler_d(regs_t *r) {
+    panic("Data abort at %x\n", r->regs[REGS_PC]);
+}
+
+void sw_tlb_handler_initialize(unsigned lockdown_start_idx) {
+
+    assert(lockdown_start_idx < 8);
+    lockdown_off = lockdown_start_idx;
+    lockdown_len = 8 - lockdown_start_idx;
+
+    full_except_set_prefetch(sw_tlb_handler_i);
+    full_except_set_data_abort(sw_tlb_handler_d);
+}

--- a/labs/x-sw-tlb/code/sw-tlb-handler.c
+++ b/labs/x-sw-tlb/code/sw-tlb-handler.c
@@ -35,6 +35,7 @@ static void sw_tlb_handler_common(uint32_t faulting_va) {
     assert(map.entries != NULL);
     assert(map.log_capacity > 0);
     sw_tlb_num_exceptions++;
+    faulting_va &= ~0xfffu;
 
     uint32_t faulting_vpn = faulting_va >> 12;
     uint32_t faulting_pa;
@@ -50,6 +51,8 @@ static void sw_tlb_handler_common(uint32_t faulting_va) {
     }
     assert(faulting_va >> 12 == faulting_vpn);
     assert(faulting_pa >> 12 == faulting_pfn);
+    assert((faulting_va & 0xfffu) == 0);
+    assert((faulting_pa & 0xfffu) == 0);
 
     assert(round_robin_counter < lockdown_len);
     sw_tlb_set(

--- a/labs/x-sw-tlb/code/sw-tlb-handler.h
+++ b/labs/x-sw-tlb/code/sw-tlb-handler.h
@@ -1,0 +1,27 @@
+//! \file sw-tlb-handler.h
+//! \brief Exception handling for the software TLB
+//! \author Ammar Ratnani <ammrat13@gmail.com>
+//!
+//! This file defines how to set up the exception handlers to set up the
+//! software TLB. Specifically, the function `sw_tlb_handler_initialize` will
+//! register exception handlers on prefetch and data aborts. The exception
+//! handlers should provide the illusion of memory from 0x80000000 up to
+//! 0xffffffff - i.e. in the upper half of the address space.
+
+#pragma once
+
+//! \brief Initialize the exception handlers for the software TLB
+//!
+//! This function is called after the heap has been initialized and the MMU has
+//! been enabled. It is responsible for setting up the exception handlers and
+//! allocating any structures they need to function.
+//!
+//! The exception handlers must not use any lockdown indicies before the one
+//! passed in. This is because the first few lockdown indicies are used to map
+//! the kernel and devices.
+//!
+//! \param sw_tlb_idx The first free lockdown index
+void sw_tlb_handler_initialize(unsigned lockdown_start_idx);
+
+//! \brief The number of exceptions that have occured
+extern volatile unsigned sw_tlb_num_exceptions;

--- a/labs/x-sw-tlb/code/sw-tlb-handler.h
+++ b/labs/x-sw-tlb/code/sw-tlb-handler.h
@@ -24,4 +24,7 @@
 void sw_tlb_handler_initialize(unsigned lockdown_start_idx);
 
 //! \brief The number of exceptions that have occured
-extern volatile unsigned sw_tlb_num_exceptions;
+//!
+//! Note that this isn't `volatile`. It doesn't need to be, since we never rely
+//! on it being modified in the middle of a function.
+extern unsigned sw_tlb_num_exceptions;

--- a/labs/x-sw-tlb/code/sw-tlb-map.c
+++ b/labs/x-sw-tlb/code/sw-tlb-map.c
@@ -1,0 +1,110 @@
+#include "sw-tlb-map.h"
+
+//! \brief Get the capacity of the hashmap
+static size_t CAP(const sw_tlb_map_t *map) {
+    assert(map != NULL);
+    assert(map->log_capacity < 30);
+    return 1u << map->log_capacity;
+}
+//! \brief Get the mask for iterating over the hashmap
+static size_t MASK(const sw_tlb_map_t *map) {
+    return CAP(map) - 1;
+}
+
+//! \brief Hash a virtual page number into the hashmap
+//! \see https://stackoverflow.com/questions/11871245/knuth-multiplicative-hash
+static size_t sw_tlb_map_hash(const sw_tlb_map_t *map, uint32_t vpn) {
+    assert(map != NULL);
+    assert(vpn < (1u << 20));
+    return (2654435761u * vpn) >> (32 - map->log_capacity);
+}
+
+sw_tlb_map_t sw_tlb_map_create(void) {
+
+    const size_t INIT_LOG_CAP = 7;
+    const size_t INIT_CAP = 1u << INIT_LOG_CAP;
+
+    // The entries are all cleared to zero by `kmalloc`, so they're all invalid
+    sw_tlb_map_entry_t *ents = kmalloc(INIT_CAP * sizeof(sw_tlb_map_entry_t));
+    assert(ents != NULL);
+
+    return (sw_tlb_map_t) {
+        .entries = ents,
+        .log_capacity = INIT_LOG_CAP,
+        .size = 0,
+    };
+}
+
+int sw_tlb_map_contains(const sw_tlb_map_t *map, uint32_t vpn, uint32_t *pfn) {
+    assert(map != NULL);
+    assert(vpn < (1u << 20));
+
+    // Compute the initial index
+    size_t initial_idx = sw_tlb_map_hash(map, vpn);
+    // Use linear probing
+    for (size_t i = 0u; i < CAP(map); i++) {
+        // Retrieve
+        size_t idx = (initial_idx + i) & MASK(map);
+        sw_tlb_map_entry_t *ent = &map->entries[idx];
+        // Process
+        if (!ent->valid)
+            return 0;
+        if (ent->vpn == vpn) {
+            if (pfn != NULL)
+                *pfn = ent->pfn;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void sw_tlb_map_add(sw_tlb_map_t *map, uint32_t vpn, uint32_t pfn) {
+    assert(map != NULL);
+    assert(vpn < (1u << 20));
+    assert(pfn < (1u << 20));
+
+    // Resize if necessary
+    static int resizing = 0;
+    if (map->size >= (CAP(map) / 4) * 3) {
+        assert(!resizing);
+        resizing = 1;
+
+        // Create a new map with double the capacity
+        size_t new_log_cap = map->log_capacity + 1;
+        size_t new_cap = 1u << new_log_cap;
+        sw_tlb_map_entry_t *new_ents =
+            kmalloc(new_cap * sizeof(sw_tlb_map_entry_t));
+        assert(new_ents != NULL);
+        sw_tlb_map_t new_map = {
+            .entries = new_ents,
+            .log_capacity = new_log_cap,
+            .size = 0,
+        };
+
+        // Rehash
+        for (size_t i = 0u; i < CAP(map); i++) {
+            sw_tlb_map_entry_t *ent = &map->entries[i];
+            if (ent->valid)
+                sw_tlb_map_add(&new_map, ent->vpn, ent->pfn);
+        }
+        // Update
+        *map = new_map;
+        resizing = 0;
+    }
+
+    // Insert using linear probing
+    size_t initial_idx = sw_tlb_map_hash(map, vpn);
+    for (size_t i = 0u; i < CAP(map); i++) {
+        size_t idx = (initial_idx + i) & MASK(map);
+        sw_tlb_map_entry_t *ent = &map->entries[idx];
+        if (!ent->valid) {
+            ent->valid = 1;
+            ent->vpn = vpn;
+            ent->pfn = pfn;
+            map->size++;
+            return;
+        }
+    }
+    // We must have had space in the map, so this should never happen
+    assert(0);
+}

--- a/labs/x-sw-tlb/code/sw-tlb-map.h
+++ b/labs/x-sw-tlb/code/sw-tlb-map.h
@@ -1,0 +1,55 @@
+//! \file sw-tlb-hashmap.h
+//! \brief Hashmap to store the mappings between virtual and physical addresses
+//! \author Ammar Ratnani <ammrat13@gmail.com>
+//!
+//! We need to have a backing store in main memory to remember all the mappings
+//! we've had in the past so that they can safely be evicted from the TLB. This
+//! solution implements it as a hashmap, where the key is the virtual page
+//! number and the value is the physical frame number.
+
+#pragma once
+
+#include "rpi.h"
+
+_Static_assert(sizeof(unsigned) == sizeof(uint32_t));
+_Static_assert(sizeof(size_t) == sizeof(uint32_t));
+
+//! \brief Type of each entry in the hashmap
+//!
+//! Note that we don't provide a way to delete entries from the hashmap, as
+//! evidenced by the fact we don't have a way to mark tombstones. This is fine,
+//! because we only serve one process.
+typedef struct sw_tlb_map_entry_t {
+    int valid: 1;
+    uint32_t vpn: 20;
+    uint32_t pfn: 20;
+} sw_tlb_map_entry_t;
+
+_Static_assert(sizeof(sw_tlb_map_entry_t) == 8);
+
+//! \brief Structure containing metadata for the entries array
+typedef struct sw_tlb_map_t {
+    sw_tlb_map_entry_t *entries;
+    size_t log_capacity;
+    size_t size;
+} sw_tlb_map_t;
+
+//! \brief Create a hashmap
+sw_tlb_map_t sw_tlb_map_create(void);
+
+//! \brief Check if a virtual page is in the hashmap
+//! \param[in] map The hashmap to check
+//! \param[in] va The virtual page number to check
+//! \param[out] pa The physical frame number if it is in the hashmap
+//! \return 1 if the virtual page is in the hashmap, 0 otherwise
+int sw_tlb_map_contains(const sw_tlb_map_t *map, uint32_t vpn, uint32_t *pfn);
+
+//! \brief Add an entry to a hashmap
+//!
+//! This function can trigger a resizing of the map, so the `entries` field of
+//! the map may change.
+//!
+//! \param[inout] map The hashmap to add to
+//! \param[in] va The virtual page number to add
+//! \param[in] pa The physical frame number to add
+void sw_tlb_map_add(sw_tlb_map_t *map, uint32_t vpn, uint32_t pfn);

--- a/labs/x-sw-tlb/code/sw-tlb-mmu-init.S
+++ b/labs/x-sw-tlb/code/sw-tlb-mmu-init.S
@@ -1,0 +1,44 @@
+#include "rpi-asm.h"
+#include "armv6-coprocessor-asm.h"
+
+MK_FN(sw_tlb_mmu_init)
+
+    // Invalidate all of the caches, especially since they might be holding
+    // invalid data because of initialization.
+    INV_ALL_CACHES(r1)
+    INV_TLB(r1)
+    // Will deal with BTB later
+
+    // Have to DSB since we did a cache maintenance operation
+    DSB(r1)
+    // Will PrefetchFlush later
+
+    // Disable hardware page table walks
+    mov r1, #0x30
+    TTBR_BASE_CTRL_WR(r1)
+    // Set the domains to what was passed as a parameter
+    DOMAIN_CTRL_WR(r0)
+
+    // Must flush BTB since we wrote to a TTB register
+    FLUSH_BTB(r1)
+
+    // Have to prefetch flush because we modified CP15 registers
+    PREFETCH_FLUSH(r1)
+    bx lr
+
+MK_FN(sw_tlb_mmu_enable)
+
+    // Note that all the caches are already clean
+
+    // Enable the caches, the branch predictor, and the MMU
+    CONTROL_REG1_RD(r0)
+    orr r0, #(0b11 << 11)
+    orr r0, #(0b101 << 0)
+    CONTROL_REG1_WR(r0)
+
+    // Must flush the BTB since we enabled the MMU
+    FLUSH_BTB(r0)
+
+    // Have to prefetch flush since we modified CP15 registers
+    PREFETCH_FLUSH(r0)
+    bx lr

--- a/labs/x-sw-tlb/code/sw-tlb-mmu-write.c
+++ b/labs/x-sw-tlb/code/sw-tlb-mmu-write.c
@@ -1,0 +1,38 @@
+#include "rpi.h"
+#include "asm-helpers.h"
+
+#include "pinned-vm.h"
+#include "sw-tlb-mmu.h"
+
+cp_asm(lockdown_index, p15, 5, c15, c4, 2)
+cp_asm(lockdown_va, p15, 5, c15, c5, 2)
+cp_asm(lockdown_pa, p15, 5, c15, c6, 2)
+cp_asm(lockdown_attr, p15, 5, c15, c7, 2)
+
+void sw_tlb_set(unsigned idx,
+                uint32_t va,
+                uint32_t pa,
+                pin_t e) {
+
+    // We only have 8 lockdown entries
+    assert(idx < 8);
+    // Pages can only go down to 4KiB
+    assert((va & 0xfffu) == 0);
+    assert((pa & 0xfffu) == 0);
+
+    uint32_t attr = (e.dom << 7) | (e.mem_attr << 1);
+    uint32_t va_ent = va | (e.G << 9) | e.asid;
+    uint32_t pa_ent = pa | (e.pagesize << 6) | (e.AP_perm << 1) | 1;
+    lockdown_index_set(idx);
+    lockdown_attr_set(attr);
+    lockdown_va_set(va_ent);
+    lockdown_pa_set(pa_ent);
+
+    uint32_t x;
+    if((x = lockdown_va_get()) != va_ent)
+        panic("lockdown va: expected %x, have %x\n", va_ent,x);
+    if((x = lockdown_pa_get()) != pa_ent)
+        panic("lockdown pa: expected %x, have %x\n", pa_ent,x);
+    if((x = lockdown_attr_get()) != attr)
+        panic("lockdown attr: expected %x, have %x\n", attr,x);
+}

--- a/labs/x-sw-tlb/code/sw-tlb-mmu.h
+++ b/labs/x-sw-tlb/code/sw-tlb-mmu.h
@@ -1,0 +1,21 @@
+//! \file sw-tlb-mmu.h
+//! \brief MMU configuration for the software TLB
+//! \author Ammar Ratnani <ammrat13@gmail.com>
+//!
+//! It turns out that configuring the MMU to support the software TLB is
+//! sufficiently different from the normal MMU configuration to warrant separate
+//! code. Thus, this file allows the user to initialize and enable the MMU so
+//! that it doesn't do any hardware page-table walks. Finally, it enables caches
+//! and branch prediction to speed up the benchmark.
+
+#pragma once
+#include <stdint.h>
+#include "pinned-vm.h"
+
+void sw_tlb_mmu_init(uint32_t domain_access_control);
+void sw_tlb_mmu_enable(void);
+
+void sw_tlb_set(unsigned idx,
+                uint32_t va,
+                uint32_t pa,
+                pin_t e);

--- a/labs/x-sw-tlb/code/tests/0-data-test.c
+++ b/labs/x-sw-tlb/code/tests/0-data-test.c
@@ -4,4 +4,7 @@
 
 void notmain(void) {
     test_setup();
+
+    PUT32(0x80000000u, 0xdeadbeefu);
+    assert(GET32(0x80000000u) == 0xdeadbeefu);
 }

--- a/labs/x-sw-tlb/code/tests/0-instr-test.c
+++ b/labs/x-sw-tlb/code/tests/0-instr-test.c
@@ -1,0 +1,13 @@
+#include "rpi.h"
+
+#include "tests/common.h"
+
+void notmain(void) {
+    test_setup();
+
+    PUT32(0x80000000u, 0xe3a00024u);
+    PUT32(0x80000004u, 0xe12fff1eu);
+
+    uint32_t (*f)(void) = (void *)0x80000000u;
+    assert(f() == 0x24u);
+}

--- a/labs/x-sw-tlb/code/tests/0-smoke-test.c
+++ b/labs/x-sw-tlb/code/tests/0-smoke-test.c
@@ -1,0 +1,7 @@
+#include "rpi.h"
+
+#include "tests/common.h"
+
+void notmain(void) {
+    test_setup();
+}

--- a/labs/x-sw-tlb/code/tests/1-history-test.c
+++ b/labs/x-sw-tlb/code/tests/1-history-test.c
@@ -1,0 +1,14 @@
+#include "rpi.h"
+
+#include "tests/common.h"
+
+void notmain(void) {
+    test_setup();
+
+    for (size_t i = 0u; i < 16u; i++) {
+        PUT32(0x80000000u + i * 0x1000000u, i);
+        assert(GET32(0x80000000u + i * 0x1000000u) == i);
+    }
+    for (size_t i = 0u; i < 16u; i++)
+        assert(GET32(0x80000000u + i * 0x1000000u) == i);
+}

--- a/labs/x-sw-tlb/code/tests/1-instr-test.c
+++ b/labs/x-sw-tlb/code/tests/1-instr-test.c
@@ -10,6 +10,9 @@ void notmain(void) {
     PUT32(0x80000000u, 0xe3a00024u);
     PUT32(0x80000004u, 0xe12fff1eu);
 
+    for (size_t i = 0u; i < 16u; i++)
+        GET32(0x90000000u + i * 0x1000000u);
+
     uint32_t (*f)(void) = (void *)0x80000000u;
     assert(f() == 0x24u);
 }

--- a/labs/x-sw-tlb/code/tests/1-long-history-test.c
+++ b/labs/x-sw-tlb/code/tests/1-long-history-test.c
@@ -1,0 +1,14 @@
+#include "rpi.h"
+
+#include "tests/common.h"
+
+void notmain(void) {
+    test_setup();
+
+    for (size_t i = 0u; i < 512u; i++) {
+        PUT32(0x80000000u + i * 0x1000u, i);
+        assert(GET32(0x80000000u + i * 0x1000u) == i);
+    }
+    for (size_t i = 0u; i < 512u; i++)
+        assert(GET32(0x80000000u + i * 0x1000u) == i);
+}

--- a/labs/x-sw-tlb/code/tests/2-multi-page-test.c
+++ b/labs/x-sw-tlb/code/tests/2-multi-page-test.c
@@ -1,0 +1,22 @@
+#include "rpi.h"
+
+#include "tests/common.h"
+
+void notmain(void) {
+    test_setup();
+
+    // mov r0, #0x90000000
+    // ldr r0, [r0]
+    // bx lr
+    PUT32(0x80000000u, 0xe3a00209u);
+    PUT32(0x80000004u, 0xe5900000u);
+    PUT32(0x80000008u, 0xe12fff1eu);
+
+    PUT32(0x90000000u, 0xdeadbeefu);
+
+    for (size_t i = 2u; i < 16u; i++)
+        GET32(0xa0000000u + i * 0x1000000u);
+
+    uint32_t (*f)(void) = (void *)0x80000000u;
+    assert(f() == 0xdeadbeefu);
+}

--- a/labs/x-sw-tlb/code/tests/2-zero-test.c
+++ b/labs/x-sw-tlb/code/tests/2-zero-test.c
@@ -1,0 +1,10 @@
+#include "rpi.h"
+
+#include "tests/common.h"
+
+void notmain(void) {
+    test_setup();
+
+    for (size_t i = 0; i < 4u * 1024u * 1024u; i += 4u)
+        assert(GET32(0x80000000u + i) == 0u);
+}

--- a/labs/x-sw-tlb/code/tests/3-microbenchmark-test.c
+++ b/labs/x-sw-tlb/code/tests/3-microbenchmark-test.c
@@ -1,0 +1,76 @@
+#include "rpi.h"
+
+#include "sw-tlb-handler.h"
+#include "tests/common.h"
+
+// Generator for normal random numbers. This just uses an LCG.
+static uint32_t rand(uint32_t *seed) {
+    *seed = *seed * 1664525 + 1013904223;
+    return *seed;
+}
+
+// Generator for virtual addresses. These have the additional requirement of
+// being aligned to 4KiB, being in the range 0x80000000 to 0xfffff000, and never
+// being the first page in that range. They also have to never repeat. To do
+// this, we use a primitive polynomial in GF(2^19).
+static uint32_t next_va(uint32_t va) {
+    // Compute the seed value from the address
+    assert((va & 0xfff) == 0);
+    assert(va >= 0x80000000u);
+    uint32_t seed = (va >> 12) - 0x80000u;
+    assert(seed != 0);
+
+    // Multiply by x modulo x^19 + x^5 + x^2 + x^1 + 1
+    uint32_t next = seed << 1;
+    if ((next & ~0x7ffffu) != 0) {
+        next &= 0x7ffffu;
+        next ^= 0x00023u;
+    }
+
+    assert(next != 0);
+    return (0x80000u + next) << 12;
+}
+
+void notmain(void) {
+    test_setup();
+
+    uint32_t seed = 0x24142414u;
+    uint32_t seed_va = (rand(&seed) & ~0xfffu) | 0x80000000u;
+    assert(seed_va != 0x80000000u);
+
+    uint32_t *result = (uint32_t *)0x80000000;
+    uint32_t *a = (uint32_t *)seed_va;
+    uint32_t *b = (uint32_t *)next_va(seed_va);
+
+    // Populate the previous pages with random values
+    for (size_t i = 0u; i < 1024u; i++) {
+        a[i] = rand(&seed);
+        b[i] = rand(&seed);
+    }
+
+    for (size_t n = 0u; n < 1024u; n++) {
+        // Get a new page. It should be all zero
+        uint32_t *x = (uint32_t *)next_va((uint32_t)b);
+        for (size_t i = 0u; i < 1024u; i++)
+            assert(x[i] == 0u);
+        // Sum the previous two pages
+        for (size_t i = 0u; i < 1024u; i++)
+            x[i] = a[i] + b[i];
+        // Place into the result buffer
+        result[n] = (uint32_t)x[1023u];
+        // Update pointers
+        a = b;
+        b = x;
+    }
+
+    // Print a checksum
+    uint32_t sum = 0u;
+    for (size_t i = 0u; i < 1024u; i++)
+        sum += result[i];
+    output("Checksum: %x\n", sum);
+
+    // Print stats
+    output("Exceptions: %u\n", sw_tlb_num_exceptions);
+    output("Memory Use: %u B\n",
+        (uint32_t)((char *)kmalloc_heap_ptr() - (char *)kmalloc_heap_start()));
+}

--- a/labs/x-sw-tlb/code/tests/common.c
+++ b/labs/x-sw-tlb/code/tests/common.c
@@ -6,19 +6,21 @@
 #include "tests/common.h"
 
 void test_setup(void) {
-    const uint32_t STACK_START = STACK_ADDR - 0x1000000u;
-    const uint32_t INT_STACK_START = INT_STACK_ADDR - 0x1000000u;
+    const uint32_t STACK_START = STACK_ADDR - 0x100000u;
+    const uint32_t INT_STACK_START = INT_STACK_ADDR - 0x100000u;
     unsigned sw_tlb_idx = 0u;
 
     // Everything should be in domain 1
     sw_tlb_mmu_init(0b0100u);
 
-    // Map the code, heap, and stack
+    // Map the code and heap
     pin_t kern_perm =
         pin_16mb(pin_mk_global(dom_kern, perm_rw_priv, MEM_wb_noalloc));
     sw_tlb_set(sw_tlb_idx++, 0x00000000u, 0x00000000u, kern_perm);
+    // Map the stack
+    pin_t stack_perm = pin_mk_global(dom_kern, perm_rw_priv, MEM_wb_noalloc);
     sw_tlb_set(sw_tlb_idx++, STACK_START, STACK_START, kern_perm);
-    sw_tlb_set(sw_tlb_idx++, INT_STACK_START, INT_STACK_START, kern_perm);
+    sw_tlb_set(sw_tlb_idx++, INT_STACK_START, INT_STACK_START, stack_perm);
     // Map devices
     pin_t dev_perm = pin_16mb(pin_mk_device(dom_kern));
     sw_tlb_set(sw_tlb_idx++, 0x20000000u, 0x20000000u, dev_perm);

--- a/labs/x-sw-tlb/code/tests/common.c
+++ b/labs/x-sw-tlb/code/tests/common.c
@@ -1,0 +1,34 @@
+#include "rpi.h"
+#include "full-except.h"
+
+#include "sw-tlb-handler.h"
+#include "sw-tlb-mmu.h"
+#include "tests/common.h"
+
+void test_setup(void) {
+    const uint32_t STACK_START = STACK_ADDR - 0x1000000u;
+    const uint32_t INT_STACK_START = INT_STACK_ADDR - 0x1000000u;
+    unsigned sw_tlb_idx = 0u;
+
+    // Everything should be in domain 1
+    sw_tlb_mmu_init(0b0100u);
+
+    // Map the code, heap, and stack
+    pin_t kern_perm =
+        pin_16mb(pin_mk_global(dom_kern, perm_rw_priv, MEM_wb_noalloc));
+    sw_tlb_set(sw_tlb_idx++, 0x00000000u, 0x00000000u, kern_perm);
+    sw_tlb_set(sw_tlb_idx++, STACK_START, STACK_START, kern_perm);
+    sw_tlb_set(sw_tlb_idx++, INT_STACK_START, INT_STACK_START, kern_perm);
+    // Map devices
+    pin_t dev_perm = pin_16mb(pin_mk_device(dom_kern));
+    sw_tlb_set(sw_tlb_idx++, 0x20000000u, 0x20000000u, dev_perm);
+
+    sw_tlb_mmu_enable();
+
+    // The heap can go until the end of the first page, or up to 16MiB
+    kmalloc_init_set_start((void *)0x100000u, 0xf00000u);
+
+    // Have the student install their exception handler
+    full_except_install(1);
+    sw_tlb_handler_initialize(sw_tlb_idx);
+}

--- a/labs/x-sw-tlb/code/tests/common.h
+++ b/labs/x-sw-tlb/code/tests/common.h
@@ -1,0 +1,6 @@
+//! \file common.h
+//! \brief Common test setup code
+//! \author Ammar Ratnani <ammrat13@gmail.com>
+
+#pragma once
+void test_setup(void);

--- a/libpi/Makefile
+++ b/libpi/Makefile
@@ -10,10 +10,13 @@ STAFF_OBJS  +=  ./staff-objs/gpio.o
 # you would add the path to yours.
 STAFF_OBJS  +=  ./staff-objs/uart.o
 STAFF_OBJS  +=  ./staff-objs/gpio-pud.o
-STAFF_OBJS  +=  ./staff-objs/gpio-int.o 
+STAFF_OBJS  +=  ./staff-objs/gpio-int.o
 STAFF_OBJS  +=  ./staff-objs/kmalloc.o
+STAFF_OBJS  +=  ./staff-objs/staff-full-except.o
+STAFF_OBJS  +=  ./staff-objs/staff-full-except-asm.o
+STAFF_OBJS  +=  ./staff-objs/staff-switchto-asm.o
 
-# you should not have to modify this variable.  
+# you should not have to modify this variable.
 SRC :=  $(SRC)                              \
         $(wildcard ./libc/*.[Sc])           \
         $(wildcard ./staff-src/*.[Sc])      \

--- a/libpi/include/armv6-coprocessor-asm.h
+++ b/libpi/include/armv6-coprocessor-asm.h
@@ -1,0 +1,136 @@
+#ifndef __ARM_COPROCESSOR_INSTS_H__
+#define __ARM_COPROCESSOR_INSTS_H__
+/*
+ * engler, cs140e: a very partial set of the co-processor instructions.
+ * the is an outrageous abundance of them in ch 3 in arm1176: a good 
+ * final project is packaging them up and making an interesting subsystem.
+ *
+ * this header just contains raw instructions.  the cookbook sequences from
+ * the arm manual are mainly in your-vm-asm.S (written by you) and mmu-asm.h
+ */
+
+/************************************************************************
+ * b4-39-
+ * all vmsa-related registers are accessed with instructions of the form:
+ *   mrc p15, 0, Rd, CRn, CRm, opcode_2
+ *   mcr p15, 0, Rd, CRn, CRm, opcode_2
+ *
+ * where CRn is the system co-processor registered.   Unless otherwise specified,
+ * CRm and opcode_2 SBZ (should be zero).  [You can see how this plays out below]
+ *
+ */
+
+/* 
+ * DSB used to be called "drain write buffer"
+ * includes all cache operations.  is a superset (>) DMB
+ */
+#define DSB(Rd)             mcr p15, 0, Rd, c7, c10, 4
+#define DMB(Rd)             mcr p15, 0, Rd, c7, c10, 5 
+
+/*
+ * must flush the prefetch buffer whenever you change a virtual
+ * mapping (ASID, PTE, etc) since it will have stale instructions.
+ *
+ * if you are doing this, likely have to do a DSB before to make
+ * sure whatever invalidation you did has completed.
+ */
+#define PREFETCH_FLUSH(Rd)  mcr p15, 0, Rd, c7, c5, 4  
+/* must do this after changing any MMU stuff, ASID, etc. */
+#define FLUSH_BTB(Rd)         mcr p15, 0, Rd, c7, c5, 6
+
+/*
+ * Work-around for bug in ARMv6 if we have seperate I/D.  Taken from:
+ *   https://elixir.bootlin.com/linux/latest/source/arch/arm/mm/cache-v6.S
+ * MUST HAVE INTERRUPTS DISABLED!
+ * XXX: patch feedback implies we need this for other operations too?
+ */
+#define INV_ICACHE(Rd)                                           \
+    mcr p15, 0, Rd, c7, c5, 0   ; /* invalidate entire I-cache */   \
+    mcr p15, 0, Rd, c7, c5, 0;  ; /* invalidate entire I-cache */   \
+    mcr p15, 0, Rd, c7, c5, 0;  ; /* invalidate entire I-cache */   \
+    mcr p15, 0, Rd, c7, c5, 0;  ; /* invalidate entire I-cache */   \
+    .rept   11                  ; /* ARM Ltd recommends at least 11 nops */\
+    nop                         ;                                   \
+    .endr
+
+/*
+ * arm1176.pdf 3-74
+ * If it is essential that the cache is clean, or clean and invalid, for
+ * a particular operation, the sequence of instructions for cleaning,
+ * or cleaning and invalidating, the cache for that operation must
+ * handle the arrival of an interrupt at any time when interrupts are not
+ * disabled. This is because interrupts can write to a previously clean
+ * cache. For this reason, the Cache Dirty Status Register indicates
+ * if the cache has been written to since the last clean of the cache
+ * was started, see Cache Dirty Status Register on page 3-78. You can
+ * interrogate the Cache Dirty Status Register to determine if the cache
+ * is clean, and if this is done while interrupts are disabled, the
+ * following operations can rely on having a clean cache.  The following
+ * sequence shows this approach:
+ */
+#define CLEAN_INV_DCACHE(Rd)    mcr p15, 0, Rd, c7, c14, 0  
+#define INV_DCACHE(Rd)          mcr p15, 0, Rd, c7, c6, 0  
+
+
+// Note: I'm inclined to believe the icache bug above effects the arm invalidate
+// all caches operation too, so we inv both I/D separately rather than use:
+//      #define INV_ALL_CACHES(Rd)  mcr p15, 0, Rd, c7, c7, 0  
+#define INV_ALL_CACHES(Rd) INV_ICACHE(Rd); INV_DCACHE(Rd)
+
+/*
+ *
+ * b4-45 --- tlb control functions. cr8 is a write only register used to
+ * control tlbs.  this is a subset.
+ * read b2-22: TLB maintance operations and the memory order model.
+ *
+ * there are other functions, such as invalidate asid and invalidate
+ * a single entry.  we may do later.
+ *
+ * i think we have to invalidate the BTB and Prefetch if doing these.
+ */
+
+#define INV_ITLB(Rd)        mcr p15, 0, Rd, c8, c5, 0 
+#define INV_DTLB(Rd)        mcr p15, 0, Rd, c8, c6, 0 
+/* invalidate unified TLB or both I/D TLB */
+#define INV_TLB(Rd)         mcr p15, 0, Rd, c8, c7, 0
+
+/*
+ * 3-61 in arm1176.pdf
+ * almost certainly do not want to do the write (*_SET) operations standalone.  
+ * there's a complicated little dance you must obey.
+ */
+#define TTBR0_GET(Rd)           mrc p15, 0, Rd, c2, c0, 0
+#define TTBR0_SET(Rd)           mcr p15, 0, Rd, c2, c0, 0
+#define TTBR1_GET(Rd)           mrc p15, 0, Rd, c2, c0, 1
+#define TTBR1_SET(Rd)           mcr p15, 0, Rd, c2, c0, 1
+#define TTBR_BASE_CTRL_RD(Rd)   mrc p15, 0, Rd, c2, c0, 2
+#define TTBR_BASE_CTRL_WR(Rd)   mcr p15, 0, Rd, c2, c0, 2
+
+// b4-52: 
+//   - context id: has both the procid (24-bits, defined by user)
+// and 
+//   - asid: 64.  must reserve asid=0.
+#define ASID_SET(Rd)            mcr p15, 0, Rd, c13, c0, 1
+#define ASID_GET(Rd)            mrc p15, 0, Rd, c13, c0, 1
+
+/* arm1176 3-63 */
+#define DOMAIN_CTRL_RD(Rd)      mrc p15, 0, Rd, c3, c0, 0
+#define DOMAIN_CTRL_WR(Rd)      mcr p15, 0, Rd, c3, c0, 0
+
+/* from b6-13: no WR method, correct? */
+#define CACHE_TYPE_RD(Rd)       mrc p15, 0, Rd, c0, c0, 1
+#define TLB_CONFIG_RD(Rd)       mrc p15, 0, Rd, c0, c0, 3
+
+/* b4-40 */
+#define CONTROL_REG1_RD(Rd) mrc p15, 0, Rd, c1, c0, 0
+#define CONTROL_REG1_WR(Rd) mcr p15, 0, Rd, c1, c0, 0
+
+
+// b4-43
+#define FAULT_STATUS_REG_GET(Rd) mrc p15, 0, Rd, c5, c0, 0
+
+/*
+ * many things not implemented: fault status, b4-43, watch point b4-44.  
+ * extension: fill these in!
+ */
+#endif

--- a/libpi/include/vector-base.h
+++ b/libpi/include/vector-base.h
@@ -1,0 +1,68 @@
+#ifndef __VECTOR_BASE_SET_H__
+#define __VECTOR_BASE_SET_H__
+#include "libc/bit-support.h"
+#include "asm-helpers.h"
+
+/*
+ * vector base address register:
+ *   3-121 --- let's us control where the exception jump table is!
+ *
+ * defines:
+ *  - vector_base_set
+ *  - vector_base_get
+ */
+
+// return the current value vector base is set to.
+static inline void *vector_base_get(void) {
+    void *ret;
+    asm volatile ("mrc p15, 0, %0, c12, c0, 0" : "=r" (ret) : : );
+    prefetch_flush();
+    return ret;
+}
+
+// check that not null and alignment is good.
+static inline int vector_base_chk(void *vector_base) {
+    uint32_t base = (uint32_t)vector_base;
+    return base != 0u && (base & 0x1fu) == 0u;
+}
+
+// set vector base: must not have been set already.
+static inline void vector_base_set(void *vec) {
+    if(!vector_base_chk(vec))
+        panic("illegal vector base %p\n", vec);
+
+    void *v = vector_base_get();
+    // if already set to the same vector, just return.
+    if(v == vec)
+        return;
+
+    if(v)
+        panic("vector base register already set=%p\n", v);
+
+    asm volatile ("mcr p15, 0, %0, c12, c0, 0" : : "r" (vec) :);
+    prefetch_flush();
+
+    // make sure it equals <vec>
+    v = vector_base_get();
+    if(v != vec)
+        panic("set vector=%p, but have %p\n", vec, v);
+}
+
+// set vector base to <vec> and return old value: could have
+// been previously set (i.e., non-null).
+static inline void *
+vector_base_reset(void *vec) {
+    if(!vector_base_chk(vec))
+        panic("illegal vector base %p\n", vec);
+
+    void *old_vec = vector_base_get();
+    if(vec == old_vec)
+        return old_vec;
+
+    asm volatile ("mcr p15, 0, %0, c12, c0, 0" : : "r" (vec) :);
+    prefetch_flush();
+
+    assert(vector_base_get() == vec);
+    return old_vec;
+}
+#endif


### PR DESCRIPTION
This lab disables the hardware page-table walker, and instead asks students to use the lockdown entries in the TLB to implement a software-managed TLB using the prefetch and data abort exceptions.